### PR TITLE
Fix/fix duplicate types

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Each tensor can be a multi-dimensional array of any type. Hence, the tensor has 
 {
     float16: 0,
     float32: 1,
-    float64: 2,
     uint8: 3,
     int8: 4,
     uint16: 5,

--- a/shiva/__init__.py
+++ b/shiva/__init__.py
@@ -221,7 +221,7 @@ class TensorDataTypes:
 
     # create the inverse dictionary
     DTYPE_2_NUMPY = {v: k for k, v in NUMPY_2_DTYPE.items()}
-    # add id=2 for retrocompatibility, since np.float64 has been removed
+    # add id=2 for backwards compatibility, since np.float64 has been removed
     DTYPE_2_NUMPY[2] = np.dtype(np.double).str
 
 

--- a/shiva/__init__.py
+++ b/shiva/__init__.py
@@ -221,6 +221,8 @@ class TensorDataTypes:
 
     # create the inverse dictionary
     DTYPE_2_NUMPY = {v: k for k, v in NUMPY_2_DTYPE.items()}
+    # add id=2 for retrocompatibility, since np.float64 has been removed
+    DTYPE_2_NUMPY[2] = np.dtype(np.double).str
 
 
 class TensorHeader(CustomModel, PackableHeader):
@@ -448,7 +450,7 @@ class ShivaMessage(CustomModel):
     def namespace_data(self) -> bytes:
         return self.namespace.encode("utf-8")
 
-    def flush(self) -> List[any]:
+    def flush(self) -> bytes:
         buffer = []
         buffer.append(self.global_header().pack())
 

--- a/shiva/__init__.py
+++ b/shiva/__init__.py
@@ -193,10 +193,12 @@ class TensorDataTypes:
     """
 
     # the dictionary that maps numpy types to the corresponding integer
+    # (np.float64 has been removed because it was overwritten by np.double,
+    # thus the id 2 was never present in the dictionary)
     RAW_NUMPY_2_DTYPE = {
         np.float16: 0,
         np.float32: 1,
-        np.float64: 2,
+        # np.float64: 2,
         np.uint8: 3,
         np.int8: 4,
         np.uint16: 5,


### PR DESCRIPTION
`np.float64` has been removed from the dictionary of supported types:
```
RAW_NUMPY_2_DTYPE = {
    np.float16: 0,
    np.float32: 1,
    # np.float64: 2,  <-----------------
    np.uint8: 3,
    np.int8: 4,
    np.uint16: 5,
    np.int16: 6,
    np.uint32: 7,
    np.int32: 8,
    np.uint64: 9,
    np.int64: 10,
    np.double: 11,
    np.longdouble: 12,
    np.longlong: 13,
    np.complex64: 14,
    np.complex128: 15,
    np.bool_: 17,
}
```
Since `np.float64 == np.double`, the key `np.float64` was overwritten by `np.double` and the type id 2 was never present in the mapping.
Type id 2 has been added manually to the reverse mapping to ensure that old messages can be still be parsed correctly:
```
# create the inverse dictionary
DTYPE_2_NUMPY = {v: k for k, v in NUMPY_2_DTYPE.items()}
# add id=2 for retrocompatibility, since np.float64 has been removed
DTYPE_2_NUMPY[2] = np.dtype(np.double).str
```