### PR TITLE
fix: 🩹 send also tensor data with big endian encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,11 @@ The protocol is based on a 'Send Message / Receive Message' flow. For each messa
 
 Message chunks are made as follows:
 
-> :warning: All integers (**uint32**) in headers are encoded in **big endian** during send and receive.
-
 <img src='docs/images/MessageZoom.png' />
 
 <br>
 
-> :warning: All integers (**uint32**) in headers are encoded in **big endian** during send and receive.
+> :warning: All integers (**uint32**) in headers as well as tensors data are encoded in **big endian** during send and receive.
 
 #### Magic Number & CRC
 


### PR DESCRIPTION
By default, numpy stores tensors in native order, meaning that their raw bytes will be encoded according to the machine running the code. This leads to unpredictable encoding, which can cause errors in network based communications, especially when the Shiva messages are parsed with different programming languages (python/C++/PLC), where the byte order must be known a priori.

With this fix, tensors are always stored, sent and received in big endian format.
