### PR TITLE
fix: :bug: Force native byte order in `from_shiva_message`

### DIFF
--- a/shiva/__init__.py
+++ b/shiva/__init__.py
@@ -367,7 +367,10 @@ class ShivaBridge(ABC, CustomModel):
                 elif isinstance(v, str):
                     if v.startswith(cls.TENSOR):
                         idx = int(v.split(cls.TENSOR)[1])
-                        d[k] = tensors[idx]
+                        # force native byte order since big endian is not supported
+                        # in some libraries (e.g. pytorch)
+                        tensor = tensors[idx]
+                        d[k] = tensor.astype(tensor.dtype.newbyteorder("="))
             return d
 
         obj = build(msg.metadata, msg.tensors)


### PR DESCRIPTION
The received tensors are forced to have native byte order for compatibility with libraries like pytorch. 