### PR TITLE
Fix/client and server are not blocked by exceptions

### DIFF
--- a/shiva/__init__.py
+++ b/shiva/__init__.py
@@ -1041,8 +1041,8 @@ class ShivaClientAsync:
         self, message: ShivaMessage, timeout: float = 0
     ) -> ShivaMessage:
         await ShivaMessage.send_message_async(self._writer, message)
-        responose_message = await ShivaMessage.receive_message_async(
+        response_message = await ShivaMessage.receive_message_async(
             self._reader, timeout=timeout
         )
-        responose_message.sender = self._writer.get_extra_info("peername")
-        return responose_message
+        response_message.sender = self._writer.get_extra_info("peername")
+        return response_message

--- a/shiva/__init__.py
+++ b/shiva/__init__.py
@@ -8,7 +8,16 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from asyncio import StreamReader, StreamWriter
-from typing import Callable, ClassVar, List, Mapping, Optional, Sequence, TypeVar
+from typing import (
+    Awaitable,
+    Callable,
+    ClassVar,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    TypeVar,
+)
 
 import deepdiff
 import numpy as np
@@ -668,18 +677,53 @@ class ShivaMessage(CustomModel):
         connection.send(message.namespace_data())
 
     @classmethod
-    async def receive_message_async(cls, reader: StreamReader) -> ShivaMessage:
+    async def _readexactly_async(
+        cls, reader: StreamReader, payload_size: int, timeout: float
+    ) -> bytes:
+        """Reads exactly payload_size bytes from the reader
+
+        Args:
+            reader (StreamReader): the stream reader
+            payload_size (int): the size of the payload
+            timeout (float): the timeout in seconds to wait for the
+            data (only if timeout > 0), if the timeout expires, an
+            asyncio.TimeoutError exception is raised
+
+        Returns:
+            bytes: the payload read from the socket
+
+        Raises:
+            asyncio.TimeoutError: if the timeout expires
+        """
+
+        if timeout > 0:
+            return await asyncio.wait_for(
+                reader.readexactly(payload_size), timeout=timeout
+            )
+        else:
+            return await reader.readexactly(payload_size)
+
+    @classmethod
+    async def receive_message_async(
+        cls, reader: StreamReader, timeout: float = 0
+    ) -> ShivaMessage:
         """Receives a Shiva message from the reader
 
         Args:
             reader (StreamReader): the stream reader
+            timeout (float): the timeout in seconds to wait for the
+            data (only if timeout > 0), if the timeout expires, an
+            asyncio.TimeoutError exception is raised
 
         Returns:
             ShivaMessage: the built Shiva message
+
+        Raises:
+            asyncio.TimeoutError: if the timeout expires
         """
 
         # receive the global header
-        data = await reader.readexactly(GlobalHeader.pack_size())
+        data = await cls._readexactly_async(reader, GlobalHeader.pack_size(), timeout)
         global_header = GlobalHeader.unpack(data)
         logger.debug(f"Global header: {global_header}")
 
@@ -695,7 +739,9 @@ class ShivaMessage(CustomModel):
 
         for idx in range(n_tensors):
             # receive a single tensor header
-            data = await reader.readexactly(TensorHeader.pack_size())
+            data = await cls._readexactly_async(
+                reader, TensorHeader.pack_size(), timeout
+            )
             tensor_header = TensorHeader.unpack(data)
             tensors_headers.append(tensor_header)
             logger.debug(f"Tensor [{idx}] header: {tensor_header}")
@@ -705,7 +751,7 @@ class ShivaMessage(CustomModel):
             shape_size = 4 * tensor_header.tensor_rank
 
             # receive the shape
-            data = await reader.readexactly(shape_size)
+            data = await cls._readexactly_async(reader, shape_size, timeout)
             shape = DataPackaging.unpack_ints(data)
             tensor_shapes.append(shape)
             logger.debug(f"Tensor [{idx}] shape: {shape}")
@@ -718,7 +764,7 @@ class ShivaMessage(CustomModel):
             logger.debug(f"Tensor [{idx}] expected data: {expected_data}")
 
             # receive the data
-            data = await reader.readexactly(expected_data)
+            data = await cls._readexactly_async(reader, expected_data, timeout)
 
             # convert the data into a numpy array
             t = np.frombuffer(
@@ -732,14 +778,14 @@ class ShivaMessage(CustomModel):
         logger.debug(f"Metadata expecting size: {metadata_size}")
         metadata = {}
         if metadata_size > 0:
-            data = await reader.readexactly(metadata_size)
+            data = await cls._readexactly_async(reader, metadata_size, timeout)
             metadata = json.loads(data.decode("utf-8"))
 
         # receive the namespace if any
         logger.debug(f"Namespace expecting size: {tail_string_size}")
         namespace = ""
         if tail_string_size > 0:
-            data = await reader.readexactly(tail_string_size)
+            data = await cls._readexactly_async(reader, tail_string_size, timeout)
             namespace = data.decode("utf-8")
 
         logger.debug("Message complete, sending response")
@@ -890,17 +936,13 @@ class ShivaServerAsync:
 
     def __init__(
         self,
-        on_new_message_callback: Callable[[ShivaMessage], ShivaMessage],
+        on_new_message_callback: Callable[[ShivaMessage], Awaitable[ShivaMessage]],
         on_new_connection: Optional[Callable[[tuple], None]] = None,
         on_connection_lost: Optional[Callable[[tuple], None]] = None,
-        on_error_callback: Optional[
-            Callable[[ShivaMessage, Exception], ShivaMessage]
-        ] = None,
     ) -> None:
         self._on_new_message_callback = on_new_message_callback
         self._on_new_connection = on_new_connection
         self._on_connection_lost = on_connection_lost
-        self._on_error_callback = on_error_callback
 
     async def wait_for_connections(
         self,
@@ -942,13 +984,6 @@ class ShivaServerAsync:
                 if self._on_connection_lost is not None:
                     self._on_connection_lost(peername)
                 break
-            except Exception as e:
-                logger.error(f"Error <-> {peername} -> {e}")
-                if self._on_error_callback is not None:
-                    response_message = self._on_error_callback(message, e)
-                else:
-                    response_message = ShivaMessage()
-                await ShivaMessage.send_message_async(writer, response_message)
 
     @classmethod
     async def accept_new_connections(
@@ -1002,8 +1037,12 @@ class ShivaClientAsync:
         await client.connect()
         return client
 
-    async def send_message(self, message: ShivaMessage) -> ShivaMessage:
+    async def send_message(
+        self, message: ShivaMessage, timeout: float = 0
+    ) -> ShivaMessage:
         await ShivaMessage.send_message_async(self._writer, message)
-        responose_message = await ShivaMessage.receive_message_async(self._reader)
+        responose_message = await ShivaMessage.receive_message_async(
+            self._reader, timeout=timeout
+        )
         responose_message.sender = self._writer.get_extra_info("peername")
         return responose_message


### PR DESCRIPTION
The client can set a timeout when sending a message to the server. In this way, if the server raises an exception, the client will not be stopped indefinitely.