### PR TITLE
Fix/go back to native endianness

### DIFF
--- a/shiva/bridges.py
+++ b/shiva/bridges.py
@@ -112,10 +112,7 @@ class ShivaBridge(ABC, CustomModel):
                         d[k] = None
                     if v.startswith(cls.TENSOR):
                         idx = int(v.split(cls.TENSOR)[1])
-                        # force native byte order since big endian is not supported
-                        # in some libraries (e.g. pytorch)
-                        tensor = tensors[idx]
-                        d[k] = tensor.astype(tensor.dtype.newbyteorder("="))
+                        d[k] = tensors[idx]
             return d
 
         obj = build(msg.metadata, msg.tensors)

--- a/shiva/messages.py
+++ b/shiva/messages.py
@@ -269,6 +269,10 @@ class ShivaMessage(CustomModel):
                 data,
                 dtype=tensor_header.tensor_dtype,
             ).reshape(shape)
+
+            # shiva sends tensors in big endian, convert them to the host endian
+            t = t.astype(t.dtype.newbyteorder("="))
+
             tensors.append(t)
 
         # receive the metadata if any
@@ -414,6 +418,9 @@ class ShivaMessage(CustomModel):
                 data,
                 dtype=tensor_header.tensor_dtype,
             ).reshape(shape)
+
+            # shiva sends tensors in big endian, convert them to the host endian
+            t = t.astype(t.dtype.newbyteorder("="))
 
             tensors.append(t)
 


### PR DESCRIPTION
Shiva sends the data contained in the tensors using big endian encoding, according to network communication standards. This was an issue when receiving such data and processing them with some libraries (e.g. pytorch) that cannot work with big endian encoding. Thus, in this PR we fix this behavior and tensors are always encoded back to the native endianness after being received.